### PR TITLE
Refactor some tests to work with item_tags joins

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20170912224632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
 
   create_table "item_tags", force: :cascade do |t|
     t.bigint "tag_id"
@@ -36,7 +34,6 @@ ActiveRecord::Schema.define(version: 20170912224632) do
     t.datetime "updated_at", null: false
   end
 
-
   create_table "tags", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -45,5 +42,4 @@ ActiveRecord::Schema.define(version: 20170912224632) do
 
   add_foreign_key "item_tags", "items"
   add_foreign_key "item_tags", "tags"
-
 end

--- a/spec/factories/item_tags.rb
+++ b/spec/factories/item_tags.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :item_tag do
-    tag nil
-    item nil
-  end
-end

--- a/spec/features/user_can_see_items_by_category_spec.rb
+++ b/spec/features/user_can_see_items_by_category_spec.rb
@@ -2,23 +2,31 @@ require 'rails_helper'
 
 RSpec.feature "user can see items by category" do
   scenario "from main page" do
-    tag1, tag2 = create_list(:tag, 2)
-    item1, item2, item3 = create_list(:item, 3)
-    item_tag1 = create(:item_tag, tag: tag1, item: item1)
-    item_tag2 = create(:item_tag, tag: tag1, item: item2)
-    item_tag3 = create(:item_tag, tag: tag2, item: item2)
-    item_tag4 = create(:item_tag, tag: tag2, item: item3)
+    tag1, tag2, tag3, tag4 = create_list(:tag, 4)
+    item1, item2, item3, item4 = create_list(:item, 4)
+    item1.tags << tag1
+    item2.tags << [tag1, tag2]
+    item3.tags << tag4
+    item4.tags << tag3
 
     visit("/#{tag1.name}")
 
     expect(page).to have_content(item1.name)
     expect(page).to have_content(item2.name)
-    expect(page).to_not have_content(item3.name)
+
 
     visit("/#{tag2.name}")
 
     expect(page).to have_content(item2.name)
-    expect(page).to have_content(item3.name)
+
     expect(page).to_not have_content(item1.name)
+
+    visit("/#{tag3.name}")
+
+    expect(page).to have_content(item4.name)
+
+    visit("/#{tag4.name}")
+
+    expect(page).to have_content(item3.name)
   end
 end


### PR DESCRIPTION
# Issue Number: 3

# Description of changes: Refactor test for item_tags so that joins are being created through relationships rather than manually.

# @mentions of the person or team responsible for reviewing proposed changes:
@dphilla @liambarstad @mikeyduece 