### PR TITLE
Change session so cart persists

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
   end
 
   def logout
-    session.clear
+    session.delete[:user_id]
     redirect_to root_path
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170913214109) do
+ActiveRecord::Schema.define(version: 20170914033717) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20170913214109) do
   end
 
   create_table "items", force: :cascade do |t|
-    t.float "price"
+    t.decimal "price"
     t.integer "stock_level"
     t.string "image"
     t.string "name"

--- a/spec/features/items/user_can_add_an_item_to_cart_spec.rb
+++ b/spec/features/items/user_can_add_an_item_to_cart_spec.rb
@@ -13,7 +13,6 @@ feature "As a user visiting the site" do
   context "and adds items to the cart" do
     scenario "visits cart and sees items" do
       item1 = create(:item)
-      item2 = (:item)
 
       visit items_path
 
@@ -26,7 +25,7 @@ feature "As a user visiting the site" do
       expect(current_path).to eq('/cart')
 
       expect(page).to have_content(item1.name)
-      expect(page).to have_content(item1.price)
+      expect(page).to have_content(Money.new(item1.price, "USD"))
 
       expect(page).to have_content("Order Total:")
 

--- a/spec/features/items/user_can_delete_a_cart_item_spec.rb
+++ b/spec/features/items/user_can_delete_a_cart_item_spec.rb
@@ -9,7 +9,7 @@ feature "Visitor adds items to cart" do
 
       click_on("shopping_cart")
 
-      expect(page).to have_content(item1.price)
+      expect(page).to have_content(Money.new(item1.price, "USD"))
 
       click_on("Remove")
 


### PR DESCRIPTION
#### Issue Number: 
4
#### Description of changes:
Changed session logout to only delete user_id rather than clear the whole session
#### @mentions of the person or team responsible for reviewing proposed changes:
@dphilla @mikeyduece @liambarstad 
