### PR TITLE
Closes #25: Admin edit item

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,10 +1,8 @@
 class Admin::BaseController < ApplicationController
   before_action :require_admin
-  
+
   def require_admin
     render file: '/public/404' unless current_admin?
   end
-  
-  def dashboard
-  end
+
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -21,6 +21,22 @@ class Admin::ItemsController < Admin::BaseController
     end
   end
 
+
+  def edit
+     @item = Item.find(params[:id])
+     @tags = Tag.all
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      flash[:notice] = "#{@item.name} updated."
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,1 +1,30 @@
 <h1>Edit</h1>
+
+<%= form_for([:admin, @item]) do |f| %>
+  <% if @item.errors.any? %>
+  <h3><%= pluralize(@item.errors.count, "error") %> prohibited this record from being saved:</h3>
+  <ul>
+    <% @item.errors.full_messages.each do |message| %>
+    <li>
+      <%= message %>
+    </li>
+    <% end %>
+  </ul>
+  <% end %>
+  <%= f.text_field :name, placeholder: "Name" %>
+  <%= f.number_field :price, placeholder: "Price" %>
+  <%= f.text_field :image, placeholder: "Image" %>
+  <%= f.text_area :description, placeholder: "Description" %>
+  <%= hidden_field_tag "item[tag_ids][]", nil %>
+  <% @tags.each do |tag| %>
+  <%= check_box_tag "item[tag_ids][]", tag.id, @item.tags.include?(tag.id), id: dom_id(tag) %>
+    <%= label_tag dom_id(tag), tag.name, id: 'checkbox' %><br>
+  <% end %>
+
+  <p><%= f.submit %></p>
+<% end %>
+
+
+
+
+

--- a/spec/features/admins/items/edit_spec.rb
+++ b/spec/features/admins/items/edit_spec.rb
@@ -36,7 +36,5 @@ RSpec.feature "admin can go to edit an item" do
     expect(current_path).to eq(item_path(Item.find_by(name: item.name)))
     expect(page).to have_content("#{item.name} updated")
     expect(page).to have_content(tag.name.titleize)
-
-
   end
 end

--- a/spec/features/admins/items/edit_spec.rb
+++ b/spec/features/admins/items/edit_spec.rb
@@ -1,0 +1,42 @@
+
+require 'rails_helper'
+
+RSpec.feature "admin can go to edit an item" do
+  scenario "and update that item" do
+    admin = create(:user, role: 1)
+    visit root_path
+    click_on("Login")
+    fill_in "user[name]", with: admin.name
+    fill_in "user[password]", with: "Password"
+    click_on("Log in")
+    item = create(:item)
+    tag = create(:tag)
+
+    visit "/admin/dashboard"
+    click_on "View All Items"
+
+    expect(current_path).to eq("/admin/items")
+    expect(page).to have_content(item.name)
+    expect(page).to have_content(item.description)
+    expect(page).to have_content(item.status)
+
+    click_on("Edit")
+
+    expect(current_path).to eq(edit_admin_item_path(Item.find_by(name: item.name)))
+
+    fill_in "item[name]", with: item.name
+    fill_in "item[description]", with: item.description
+    fill_in "item[price]", with: item.price
+    fill_in "item[image]", with: item.image
+    check "#{tag.name}"
+    within("p") do
+      click_on("Update")
+    end
+
+    expect(current_path).to eq(item_path(Item.find_by(name: item.name)))
+    expect(page).to have_content("#{item.name} updated")
+    expect(page).to have_content(tag.name.titleize)
+
+
+  end
+end


### PR DESCRIPTION
#### Issue Number: 25

#### Description of changes:

Admin can Edit an Item
Also, removed empty dashboard method from admin base controller 

#### @mentions of the person or team responsible for reviewing proposed changes:
@liambarstad @mikeyduece @Aram-Anderson 
